### PR TITLE
Fix spelling mistakes and create spell-checking autocmd

### DIFF
--- a/nvim/configs/main.vim
+++ b/nvim/configs/main.vim
@@ -12,6 +12,15 @@
 " Colorscheme
 colorscheme wal
 
+augroup specify_filetype
+    autocmd!
+    autocmd BufRead,BufNewFile *.md set filetype=markdown
+    autocmd BufRead,BufNewFile *.txt set filetype=text
+augroup END
+"
+" Enable spell-checking for certain files
+autocmd FileType text,markdown setlocal spell
+
 " Limit line length for text files
 autocmd FileType text,markdown,tex setlocal textwidth=180
 
@@ -136,16 +145,3 @@ augroup END
         execute "digraphs xs " . 0x2093
 "}}}
 
-
-" Enable spell-checking for certain files
-augroup markdownSpell
-    autocmd!
-    autocmd FileType markdown setlocal spell
-    autocmd BufRead,BufNewFile *.md setlocal spell
-augroup END
-
-augroup textSpell
-    autocmd!
-    autocmd FileType text setlocal spell
-    autocmd BufRead,BufNewFile *.txt setlocal spell
-augroup END

--- a/nvim/configs/main.vim
+++ b/nvim/configs/main.vim
@@ -9,7 +9,7 @@
 
 
 
-" Colorsheme
+" Colorscheme
 colorscheme wal
 
 " Limit line length for text files
@@ -18,13 +18,13 @@ autocmd FileType text,markdown,tex setlocal textwidth=180
 " Don't automatically collapse markdown
 set conceallevel=0
 
-" Don't dispay mode in command line (airilne already shows it)
+" Don't display mode in command line (airline already shows it)
 set noshowmode
 
 " Automatically re-read file if a change was detected outside of vim
 set autoread
 
-" no case sensative search unless uppercase is present
+" no case-sensitive search unless uppercase is present
 set ignorecase
 set smartcase
 
@@ -137,7 +137,7 @@ augroup END
 "}}}
 
 
-" Enable spellchecking for certain files
+" Enable spell-checking for certain files
 augroup markdownSpell
     autocmd!
     autocmd FileType markdown setlocal spell

--- a/nvim/configs/plugin-settings.vim
+++ b/nvim/configs/plugin-settings.vim
@@ -81,7 +81,7 @@ let g:NERDTreeIndicatorMapCustom = {
         \ 'ignored'   : '☒',
         \ "unknown"   : "?"
         \ }
- 
+
 
 """"""""""""
 "Airline   "
@@ -129,7 +129,7 @@ let g:airline#extensions#hunks#hunk_symbols = [':', ':', ':']
 let g:airline#extensions#branch#format = 2
 
 
-""""""""""""""
+"""""""""""""
 "Devicons   "
 """""""""""""
 let g:webdevicons_enable = 1


### PR DESCRIPTION
Creating an augroup that sets the filetype for markdown and text (respectively *.md/*.txt) allows other packages/config settings to be use on these specific glob patterns as well.